### PR TITLE
Changes in /src/Classes: added noexcept qualifier and inline methods.

### DIFF
--- a/src/Classes/Models/changesmodel.cpp
+++ b/src/Classes/Models/changesmodel.cpp
@@ -4,7 +4,7 @@
 #include <QJsonValue>
 #include "changesmodel.h"
 
-ChangesModel::ChangesModel() :
+ChangesModel::ChangesModel() noexcept :
     m_NewReleases(new QList<int>()),
     m_NewOnlineSeries(new QList<int>()),
     m_NewTorrents(new QList<int>()),
@@ -13,27 +13,7 @@ ChangesModel::ChangesModel() :
 
 }
 
-QList<int>* ChangesModel::newReleases()
-{
-    return m_NewReleases;
-}
-
-QList<int>* ChangesModel::newTorrentSeries()
-{
-    return m_NewTorrentSeries;
-}
-
-QList<int>* ChangesModel::newOnlineSeries()
-{
-    return m_NewOnlineSeries;
-}
-
-QList<int>* ChangesModel::newTorrents()
-{
-    return m_NewTorrents;
-}
-
-void ChangesModel::fromJson(QString json)
+void ChangesModel::fromJson(const QString& json)
 {
     if (json.isEmpty()) return;
 
@@ -53,7 +33,7 @@ void ChangesModel::fromJson(QString json)
     foreach (auto newTorrentSeria, newTorrentSeries) m_NewTorrentSeries->append(newTorrentSeria.toInt());
 }
 
-QString ChangesModel::toJson()
+QString ChangesModel::toJson() noexcept
 {
     QJsonObject object;
 

--- a/src/Classes/Models/changesmodel.h
+++ b/src/Classes/Models/changesmodel.h
@@ -8,7 +8,7 @@ class ChangesModel
 {
 
 public:
-    ChangesModel();
+    ChangesModel() noexcept;
 
 private:
     QList<int>* m_NewReleases;
@@ -17,17 +17,17 @@ private:
     QList<int>* m_NewTorrentSeries;
 
 public:
-    QList<int>* newReleases();
+    QList<int>* newReleases() const {return m_NewReleases;}
 
-    QList<int>* newOnlineSeries();
+    QList<int>* newOnlineSeries() const {return m_NewOnlineSeries;}
 
-    QList<int>* newTorrents();
+    QList<int>* newTorrents() const {return m_NewTorrents;}
 
-    QList<int>* newTorrentSeries();
+    QList<int>* newTorrentSeries() const {return m_NewTorrentSeries;}
 
-    void fromJson(QString json);
+    void fromJson(const QString &json);
 
-    QString toJson();
+    QString toJson() noexcept;
 
 };
 

--- a/src/Classes/Models/externalplaylistvideo.cpp
+++ b/src/Classes/Models/externalplaylistvideo.cpp
@@ -1,52 +1,39 @@
 #include "externalplaylistvideo.h"
 
-ExternalPlaylistVideo::ExternalPlaylistVideo() : m_Order(0), m_Address(""), m_Name("")
+ExternalPlaylistVideo::ExternalPlaylistVideo()
+    : m_Order(0)
+    , m_Address("")
+    , m_Name("")
 {
-
 }
 
-int ExternalPlaylistVideo::order() const
-{
-    return m_Order;
-}
-
-QString ExternalPlaylistVideo::address() const
-{
-    return m_Address;
-}
-
-QString ExternalPlaylistVideo::name() const
-{
-    return m_Name;
-}
-
-void ExternalPlaylistVideo::setOrder(int order)
+void ExternalPlaylistVideo::setOrder(int order) noexcept
 {
     m_Order = order;
 }
 
-void ExternalPlaylistVideo::setAddress(const QString &address)
+void ExternalPlaylistVideo::setAddress(const QString &address) noexcept
 {
     m_Address = address;
 }
 
-void ExternalPlaylistVideo::setName(const QString &name)
+void ExternalPlaylistVideo::setName(const QString &name) noexcept
 {
     m_Name = name;
 }
 
-QString ExternalPlaylistVideo::exportToM3U()
+QString ExternalPlaylistVideo::exportToM3U() noexcept
 {
     return "# EXTINF:-1, " + m_Name + "\n" + m_Address + "\n\n";
 }
 
-QString ExternalPlaylistVideo::exportToMPCPL()
+QString ExternalPlaylistVideo::exportToMPCPL() noexcept
 {
     QString order = QString::number(m_Order);
     return order + ",type,0\n" + order + ",label," + m_Name + "\n" + order + ",filename," + m_Address + "\n";
 }
 
-bool ExternalPlaylistVideo::operator==(const ExternalPlaylistVideo &comparedModel)
+bool ExternalPlaylistVideo::operator==(const ExternalPlaylistVideo &comparedModel) noexcept
 {
     return m_Order == comparedModel.order();
 }

--- a/src/Classes/Models/externalplaylistvideo.h
+++ b/src/Classes/Models/externalplaylistvideo.h
@@ -14,18 +14,18 @@ private:
 public:
     ExternalPlaylistVideo();
 
-    int order() const;
-    QString address() const;
-    QString name() const;
+    int order() const {return m_Order;}
+    QString address() const {return m_Address;}
+    QString name() const {return m_Name;}
 
-    void setOrder(int order);
-    void setAddress(const QString& address);
-    void setName(const QString& name);
+    void setOrder(const int order) noexcept;
+    void setAddress(const QString& address) noexcept;
+    void setName(const QString& name) noexcept;
 
-    QString exportToM3U();
-    QString exportToMPCPL();
+    QString exportToM3U() noexcept;
+    QString exportToMPCPL() noexcept;
 
-    bool operator== (const ExternalPlaylistVideo &comparedModel);
+    bool operator== (const ExternalPlaylistVideo &comparedModel) noexcept;
 };
 
 #endif // EXTERNALPLAYLISTVIDEO_H

--- a/src/Classes/Models/fullreleasemodel.cpp
+++ b/src/Classes/Models/fullreleasemodel.cpp
@@ -4,42 +4,22 @@
 #include "fullreleasemodel.h"
 #include "globalconstants.h"
 
-QString FullReleaseModel::title() const
-{
-    return m_Title;
-}
-
-void FullReleaseModel::setTitle(const QString &title)
+void FullReleaseModel::setTitle(const QString &title) noexcept
 {
     m_Title = title;
 }
 
-QString FullReleaseModel::status() const
-{
-    return m_Status;
-}
-
-void FullReleaseModel::setStatus(const QString &status)
+void FullReleaseModel::setStatus(const QString &status) noexcept
 {
     m_Status = status;
 }
 
-QString FullReleaseModel::year() const
-{
-    return m_Year;
-}
-
-void FullReleaseModel::setYear(const QString &year)
+void FullReleaseModel::setYear(const QString &year) noexcept
 {
     m_Year = year;
 }
 
-QString FullReleaseModel::poster() const
-{
-    return m_Poster;
-}
-
-void FullReleaseModel::setPoster(const QString &poster)
+void FullReleaseModel::setPoster(const QString &poster) noexcept
 {
     if (poster.contains("https://")) {
         m_Poster = poster;
@@ -48,177 +28,92 @@ void FullReleaseModel::setPoster(const QString &poster)
     }
 }
 
-QString FullReleaseModel::description() const
-{
-    return m_Description;
-}
-
-void FullReleaseModel::setDescription(const QString &description)
+void FullReleaseModel::setDescription(const QString &description) noexcept
 {
     m_Description = description;
 }
 
-QString FullReleaseModel::releaseType() const
-{
-    return m_Type;
-}
-
-void FullReleaseModel::setReleaseType(const QString &releaseType)
+void FullReleaseModel::setReleaseType(const QString &releaseType) noexcept
 {
     m_Type = releaseType;
 }
 
-QString FullReleaseModel::genres() const
-{
-    return m_Genres;
-}
-
-void FullReleaseModel::setGenres(const QString &genres)
+void FullReleaseModel::setGenres(const QString &genres) noexcept
 {
     m_Genres = genres;
 }
 
-QString FullReleaseModel::voicers() const
-{
-    return m_Voices;
-}
-
-void FullReleaseModel::setVoicers(const QString &voicers)
+void FullReleaseModel::setVoicers(const QString &voicers) noexcept
 {
     m_Voices = voicers;
 }
 
-QString FullReleaseModel::season() const
-{
-    return m_Season;
-}
-
-void FullReleaseModel::setSeason(const QString &season)
+void FullReleaseModel::setSeason(const QString &season) noexcept
 {
     m_Season = season;
 }
 
-QString FullReleaseModel::series() const
-{
-    return m_Series;
-}
-
-void FullReleaseModel::setSeries(const QString &series)
+void FullReleaseModel::setSeries(const QString &series) noexcept
 {
     m_Series = series;
 }
 
-QString FullReleaseModel::code() const
-{
-    return m_Code;
-}
-
-void FullReleaseModel::setCode(const QString &code)
+void FullReleaseModel::setCode(const QString &code) noexcept
 {
     m_Code = code;
 }
 
-int FullReleaseModel::id() const
-{
-    return m_Id;
-}
-
-void FullReleaseModel::setId(const int id)
+void FullReleaseModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-int FullReleaseModel::countOnlineVideos() const
-{
-    return m_CountVideos;
-}
-
-void FullReleaseModel::setCountOnlineVideos(const int countOnlineVideos)
+void FullReleaseModel::setCountOnlineVideos(const int countOnlineVideos) noexcept
 {
     m_CountVideos = countOnlineVideos;
 }
 
-int FullReleaseModel::countTorrents() const
-{
-    return m_CountTorrents;
-}
-
-void FullReleaseModel::setCountTorrents(const int countTorrents)
+void FullReleaseModel::setCountTorrents(const int countTorrents) noexcept
 {
     m_CountTorrents = countTorrents;
 }
 
-QString FullReleaseModel::announce() const
-{
-    return m_Announce;
-}
-
-void FullReleaseModel::setAnnounce(const QString &announce)
+void FullReleaseModel::setAnnounce(const QString &announce) noexcept
 {
     m_Announce = announce;
 }
 
-QString FullReleaseModel::originalName() const
-{
-    return m_OriginalName;
-}
-
-void FullReleaseModel::setOriginalName(const QString &originalName)
+void FullReleaseModel::setOriginalName(const QString &originalName) noexcept
 {
     m_OriginalName = originalName;
 }
 
-int FullReleaseModel::rating() const
-{
-    return m_Rating;
-}
-
-void FullReleaseModel::setRating(const int rating)
+void FullReleaseModel::setRating(const int rating) noexcept
 {
     m_Rating = rating;
 }
 
-QString FullReleaseModel::torrents() const
-{
-    return m_Torrents;
-}
-
-void FullReleaseModel::setTorrents(const QString &torrents)
+void FullReleaseModel::setTorrents(const QString &torrents) noexcept
 {
     m_Torrents = torrents;
 }
 
-QString FullReleaseModel::videos() const
-{
-    return m_Videos;
-}
-
-void FullReleaseModel::setVideos(const QString &videos)
+void FullReleaseModel::setVideos(const QString &videos) noexcept
 {
     m_Videos = videos;
 }
 
-int FullReleaseModel::timestamp() const
-{
-    return m_Timestamp;
-}
-
-void FullReleaseModel::setTimestamp(const int timestamp)
+void FullReleaseModel::setTimestamp(const int timestamp) noexcept
 {
     m_Timestamp = timestamp;
 }
 
-QString FullReleaseModel::type() const
-{
-    return m_Type;
-}
-
-void FullReleaseModel::setType(const QString &type)
+void FullReleaseModel::setType(const QString &type) noexcept
 {
     m_Type = type;
 }
 
-void FullReleaseModel::writeToJson(QJsonObject &json) const
+void FullReleaseModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["title"] = m_Title;
@@ -265,8 +160,7 @@ void FullReleaseModel::readFromJson(QJsonValue &json)
     setTorrents(json["torrents"].toString());
     setVideos(json["videos"].toString());
 }
-
-bool FullReleaseModel::operator==(const FullReleaseModel &comparedModel)
+bool FullReleaseModel::operator== (const FullReleaseModel &comparedModel) noexcept
 {
     return m_Id == comparedModel.id();
 }

--- a/src/Classes/Models/fullreleasemodel.h
+++ b/src/Classes/Models/fullreleasemodel.h
@@ -30,74 +30,74 @@ private:
     int m_Rating;
 
 public:
-    QString title() const;
-    void setTitle(const QString &title);
+    QString title() const {return m_Title;}
+    void setTitle(const QString &title) noexcept;
 
-    QString status() const;
-    void setStatus(const QString &status);
+    QString status() const {return m_Status;}
+    void setStatus(const QString &status) noexcept;
 
-    QString year() const;
-    void setYear(const QString &year);
+    QString year() const {return m_Year;}
+    void setYear(const QString &year) noexcept;
 
-    QString poster() const;
-    void setPoster(const QString &poster);
+    QString poster() const {return m_Poster;}
+    void setPoster(const QString &poster) noexcept;
 
-    QString description() const;
-    void setDescription(const QString &description);
+    QString description() const {return m_Description;}
+    void setDescription(const QString &description) noexcept;
 
-    QString releaseType() const;
-    void setReleaseType(const QString &releaseType);
+    QString releaseType() const {return m_Type;}
+    void setReleaseType(const QString &releaseType) noexcept;
 
-    QString genres() const;
-    void setGenres(const QString &genres);
+    QString genres() const {return m_Genres;}
+    void setGenres(const QString &genres) noexcept;
 
-    QString voicers() const;
-    void setVoicers(const QString &voicers);
+    QString voicers() const {return m_Voices;}
+    void setVoicers(const QString &voicers) noexcept;
 
-    QString season() const;
-    void setSeason(const QString &season);
+    QString season() const {return m_Season;}
+    void setSeason(const QString &season) noexcept;
 
-    QString series() const;
-    void setSeries(const QString &series);
+    QString series() const {return m_Series;}
+    void setSeries(const QString &series) noexcept;
 
-    QString code() const;
-    void setCode(const QString &code);
+    QString code() const {return m_Code;}
+    void setCode(const QString &code) noexcept;
 
-    int id() const;
-    void setId(const int id);
+    int id() const {return m_Id;}
+    void setId(const int id) noexcept;
 
-    int countOnlineVideos() const;
-    void setCountOnlineVideos(const int countOnlineVideos);
+    int countOnlineVideos() const {return m_CountVideos;}
+    void setCountOnlineVideos(const int countOnlineVideos) noexcept;
 
-    int countTorrents() const;
-    void setCountTorrents(const int countTorrents);
+    int countTorrents() const {return m_CountTorrents;}
+    void setCountTorrents(const int countTorrents) noexcept;
 
-    QString announce() const;
-    void setAnnounce(const QString& announce);
+    QString announce() const {return m_Announce;}
+    void setAnnounce(const QString& announce) noexcept;
 
-    QString originalName() const;
-    void setOriginalName(const QString& originalName);
+    QString originalName() const {return m_OriginalName;}
+    void setOriginalName(const QString& originalName) noexcept;
 
-    int rating() const;
-    void setRating(const int rating);
+    int rating() const {return m_Rating;}
+    void setRating(const int rating) noexcept;
 
-    QString torrents() const;
-    void setTorrents(const QString& torrents);
+    QString torrents() const {return m_Torrents;}
+    void setTorrents(const QString& torrents) noexcept;
 
-    QString videos() const;
-    void setVideos(const QString& videos);
+    QString videos() const {return m_Videos;}
+    void setVideos(const QString& videos) noexcept;
 
-    int timestamp() const;
-    void setTimestamp(const int timestamp);
+    int timestamp() const noexcept{return m_Timestamp;}
+    void setTimestamp(const int timestamp) noexcept;
 
-    QString type() const;
-    void setType(const QString& type);
+    QString type() const {return m_Type;}
+    void setType(const QString& type) noexcept;
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
 
     void readFromJson(QJsonValue &json);
 
-    bool operator== (const FullReleaseModel &comparedModel);
+    bool operator== (const FullReleaseModel &comparedModel) noexcept;
 
 };
 

--- a/src/Classes/Models/historymodel.cpp
+++ b/src/Classes/Models/historymodel.cpp
@@ -1,41 +1,28 @@
 #include "historymodel.h"
 
-HistoryModel::HistoryModel() : m_Id(0), m_Timestamp(0), m_WatchTimestamp(0)
+HistoryModel::HistoryModel()
+    : m_Id(0)
+    , m_Timestamp(0)
+    , m_WatchTimestamp(0)
 {
-
 }
 
-int HistoryModel::id() const
-{
-    return m_Id;
-}
-
-int HistoryModel::timestamp() const
-{
-    return m_Timestamp;
-}
-
-int HistoryModel::watchTimestamp() const
-{
-    return m_WatchTimestamp;
-}
-
-void HistoryModel::setId(int id)
+void HistoryModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-void HistoryModel::setTimestamp(int timestamp)
+void HistoryModel::setTimestamp(const int timestamp) noexcept
 {
     m_Timestamp = timestamp;
 }
 
-void HistoryModel::setWatchTimestamp(int watchTimestamp)
+void HistoryModel::setWatchTimestamp(const int watchTimestamp) noexcept
 {
     m_WatchTimestamp = watchTimestamp;
 }
 
-void HistoryModel::writeToJson(QJsonObject &json) const
+void HistoryModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["timestamp"] = m_Timestamp;

--- a/src/Classes/Models/historymodel.h
+++ b/src/Classes/Models/historymodel.h
@@ -15,15 +15,15 @@ private:
 public:
     HistoryModel();
 
-    int id() const;
-    int timestamp() const;
-    int watchTimestamp() const;
+    int id() const {return m_Id;}
+    int timestamp() const {return m_Timestamp;}
+    int watchTimestamp() const {return m_WatchTimestamp;}
 
-    void setId(int id);
-    void setTimestamp(int timestamp);
-    void setWatchTimestamp(int watchTimestamp);
+    void setId(const int id) noexcept;
+    void setTimestamp(const int timestamp) noexcept;
+    void setWatchTimestamp(const int watchTimestamp) noexcept;
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
     void readFromJson(QJsonValue &json);
 
 };

--- a/src/Classes/Models/onlinevideomodel.cpp
+++ b/src/Classes/Models/onlinevideomodel.cpp
@@ -16,7 +16,7 @@ void OnlineVideoModel::readFromApiModel(const QJsonObject &jsonObject)
     m_SourceHD = jsonObject.value("srcHd").toString();
 }
 
-void OnlineVideoModel::writeToJson(QJsonObject &json) const
+void OnlineVideoModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["title"] = m_Title;
@@ -27,72 +27,37 @@ void OnlineVideoModel::writeToJson(QJsonObject &json) const
     json["srcHd"] = m_SourceHD;
 }
 
-int OnlineVideoModel::id() const
-{
-    return m_Id;
-}
-
-QString OnlineVideoModel::title() const
-{
-    return m_Title;
-}
-
-QString OnlineVideoModel::sd() const
-{
-    return m_SD;
-}
-
-QString OnlineVideoModel::hd() const
-{
-    return m_HD;
-}
-
-QString OnlineVideoModel::fullhd() const
-{
-    return m_FullHD;
-}
-
-QString OnlineVideoModel::sourcesd() const
-{
-    return m_SourceSD;
-}
-
-QString OnlineVideoModel::sourcehd() const
-{
-    return m_SourceHD;
-}
-
-void OnlineVideoModel::setId(const int id)
+void OnlineVideoModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-void OnlineVideoModel::setTitle(const QString &title)
+void OnlineVideoModel::setTitle(const QString &title) noexcept
 {
     m_Title = title;
 }
 
-void OnlineVideoModel::setSd(const QString &sd)
+void OnlineVideoModel::setSd(const QString &sd) noexcept
 {
     m_SD = sd;
 }
 
-void OnlineVideoModel::setHd(const QString &hd)
+void OnlineVideoModel::setHd(const QString &hd) noexcept
 {
     m_HD = hd;
 }
 
-void OnlineVideoModel::setFullHd(const QString &fullhd)
+void OnlineVideoModel::setFullHd(const QString &fullhd) noexcept
 {
     m_FullHD = fullhd;
 }
 
-void OnlineVideoModel::setSourceSd(const QString &sourcesd)
+void OnlineVideoModel::setSourceSd(const QString &sourcesd) noexcept
 {
     m_SourceSD = sourcesd;
 }
 
-void OnlineVideoModel::setSourceHd(const QString &sourcehd)
+void OnlineVideoModel::setSourceHd(const QString &sourcehd) noexcept
 {
     m_SourceHD = sourcehd;
 }

--- a/src/Classes/Models/onlinevideomodel.h
+++ b/src/Classes/Models/onlinevideomodel.h
@@ -19,23 +19,23 @@ public:
 
     void readFromApiModel(const QJsonObject &jsonObject);
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
 
-    int id() const;
-    QString title() const;
-    QString sd() const;
-    QString hd() const;
-    QString fullhd() const;
-    QString sourcesd() const;
-    QString sourcehd() const;
+    int id() const {return m_Id;}
+    QString title() const {return m_Title;}
+    QString sd() const {return m_SD;}
+    QString hd() const noexcept {return m_HD;}
+    QString fullhd() const {return m_FullHD;}
+    QString sourcesd() const {return m_SourceSD;}
+    QString sourcehd() const {return m_SourceHD;}
 
-    void setId(const int id);
-    void setTitle(const QString &title);
-    void setSd(const QString &sd);
-    void setHd(const QString &hd);
-    void setFullHd(const QString &fullhd);
-    void setSourceSd(const QString &sourcesd);
-    void setSourceHd(const QString &sourcehd);
+    void setId(const int id) noexcept;
+    void setTitle(const QString &title) noexcept;
+    void setSd(const QString &sd) noexcept;
+    void setHd(const QString &hd) noexcept;
+    void setFullHd(const QString &fullhd) noexcept;
+    void setSourceSd(const QString &sourcesd) noexcept;
+    void setSourceHd(const QString &sourcehd) noexcept;
 };
 
 #endif // ONLINEVIDEOMODEL_H

--- a/src/Classes/Models/releasemodel.cpp
+++ b/src/Classes/Models/releasemodel.cpp
@@ -87,7 +87,7 @@ void ReleaseModel::readFromJson(const QJsonObject &json)
     }
 }
 
-void ReleaseModel::writeToJson(QJsonObject &json) const
+void ReleaseModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["code"] = m_Code;
@@ -128,94 +128,4 @@ void ReleaseModel::writeToJson(QJsonObject &json) const
         torrentsArray.append(jsonObject);
     }
     json["torrents"] = torrentsArray;
-}
-
-int ReleaseModel::id()
-{
-    return m_Id;
-}
-
-QString ReleaseModel::code()
-{
-    return m_Code;
-}
-
-QString ReleaseModel::series()
-{
-    return m_Series;
-}
-
-QString ReleaseModel::poster()
-{
-    return m_Poster;
-}
-
-QString ReleaseModel::timestamp()
-{
-    return m_Timestamp;
-}
-
-QString ReleaseModel::status()
-{
-    return m_Status;
-}
-
-QString ReleaseModel::type()
-{
-    return m_Type;
-}
-
-QString ReleaseModel::year()
-{
-    return m_Year;
-}
-
-QString ReleaseModel::description()
-{
-    return m_Description;
-}
-
-QString ReleaseModel::season()
-{
-    return m_Season;
-}
-
-QString ReleaseModel::announce()
-{
-    return m_Announce;
-}
-
-QStringList ReleaseModel::genres()
-{
-    return m_Genres;
-}
-
-QStringList ReleaseModel::voices()
-{
-    return m_Voices;
-}
-
-QStringList ReleaseModel::names()
-{
-    return m_Names;
-}
-
-int ReleaseModel::rating()
-{
-    return m_Rating;
-}
-
-QString ReleaseModel::title()
-{
-    return m_Title;
-}
-
-QList<OnlineVideoModel> ReleaseModel::videos()
-{
-    return m_Videos;
-}
-
-QList<ReleaseTorrentModel> ReleaseModel::torrents()
-{
-    return m_Torrents;
 }

--- a/src/Classes/Models/releasemodel.h
+++ b/src/Classes/Models/releasemodel.h
@@ -32,45 +32,45 @@ public:
 
     void readFromApiModel(const QJsonObject &jsonObject);
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
 
     void readFromJson(const QJsonObject &json);
 
-    int id();
+    int id() const {return m_Id;}
 
-    QString code();
+    QString code() const {return m_Code;};
 
-    QString series();
+    QString series() const {return m_Series;}
 
-    QString poster();
+    QString poster() const {return m_Poster;}
 
-    QString timestamp();
+    QString timestamp() const {return m_Timestamp;}
 
-    QString status();
+    QString status() const {return m_Status;}
 
-    QString type();
+    QString type() const {return m_Type;}
 
-    QString year();
+    QString year() const {return m_Year;};
 
-    QString description();
+    QString description() const {return m_Description;}
 
-    QString season();
+    QString season() const {return m_Season;}
 
-    QString announce();
+    QString announce() const {return m_Announce;}
 
-    QStringList genres();
+    QStringList genres() const {return m_Genres;}
 
-    QStringList voices();
+    QStringList voices() const {return m_Voices;}
 
-    QStringList names();
+    QStringList names() const {return m_Names;}
 
-    int rating();
+    int rating() const {return m_Rating;}
 
-    QString title();
+    QString title() const {return m_Title;}
 
-    QList<OnlineVideoModel> videos();
+    QList<OnlineVideoModel> videos() const {return  m_Videos;}
 
-    QList<ReleaseTorrentModel> torrents();
+    QList<ReleaseTorrentModel> torrents() const {return m_Torrents;}
 
 };
 

--- a/src/Classes/Models/releasetorrentmodel.cpp
+++ b/src/Classes/Models/releasetorrentmodel.cpp
@@ -15,7 +15,7 @@ void ReleaseTorrentModel::readFromApiModel(const QJsonObject &jsonObject)
     m_Size = jsonObject.value("size").toInt();
 }
 
-void ReleaseTorrentModel::writeToJson(QJsonObject &json) const
+void ReleaseTorrentModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["hash"] = m_Hash;
@@ -25,62 +25,32 @@ void ReleaseTorrentModel::writeToJson(QJsonObject &json) const
     json["size"] = static_cast<int>(m_Size);
 }
 
-int ReleaseTorrentModel::id() const
-{
-    return m_Id;
-}
-
-void ReleaseTorrentModel::setId(const int id)
+void ReleaseTorrentModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-QString ReleaseTorrentModel::hash() const
-{
-    return m_Hash;
-}
-
-void ReleaseTorrentModel::setHash(const QString &hash)
+void ReleaseTorrentModel::setHash(const QString &hash) noexcept
 {
     m_Hash = hash;
 }
 
-QString ReleaseTorrentModel::quality() const
-{
-    return m_Quality;
-}
-
-void ReleaseTorrentModel::setQuality(const QString &quality)
+void ReleaseTorrentModel::setQuality(const QString &quality) noexcept
 {
     m_Quality = quality;
 }
 
-QString ReleaseTorrentModel::series() const
-{
-    return m_Series;
-}
-
-void ReleaseTorrentModel::setSeries(const QString &series)
+void ReleaseTorrentModel::setSeries(const QString &series) noexcept
 {
     m_Series = series;
 }
 
-long ReleaseTorrentModel::size() const
-{
-    return m_Size;
-}
-
-void ReleaseTorrentModel::setSize(const long size)
+void ReleaseTorrentModel::setSize(const long size) noexcept
 {
     m_Size = size;
 }
 
-QString ReleaseTorrentModel::url() const
-{
-    return m_Url;
-}
-
-void ReleaseTorrentModel::setUrl(const QString &url)
+void ReleaseTorrentModel::setUrl(const QString &url) noexcept
 {
     m_Url = url;
 }

--- a/src/Classes/Models/releasetorrentmodel.h
+++ b/src/Classes/Models/releasetorrentmodel.h
@@ -18,25 +18,25 @@ public:
 
     void readFromApiModel(const QJsonObject &jsonObject);
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
 
-    int id() const;
-    void setId(const int id);
+    int id() const {return m_Id;}
+    void setId(const int id) noexcept;
 
-    QString hash() const;
-    void setHash(const QString &hash);
+    QString hash() const {return m_Hash;}
+    void setHash(const QString &hash) noexcept;
 
-    QString quality() const;
-    void setQuality(const QString &quality);
+    QString quality() const {return m_Quality;}
+    void setQuality(const QString &quality) noexcept;
 
-    QString series() const;
-    void setSeries(const QString &series);
+    QString series() const {return m_Series;}
+    void setSeries(const QString &series) noexcept;
 
-    long size() const;
-    void setSize(const long size);
+    long size() const {return m_Size;}
+    void setSize(const long size) noexcept;
 
-    QString url() const;
-    void setUrl(const QString &url);
+    QString url() const {return m_Url;}
+    void setUrl(const QString &url) noexcept;
 };
 
 #endif // RELEASETORRENTMODEL_H

--- a/src/Classes/Models/seenmarkmodel.cpp
+++ b/src/Classes/Models/seenmarkmodel.cpp
@@ -1,26 +1,16 @@
 #include "seenmarkmodel.h"
 
-int SeenMarkModel::id() const
-{
-    return m_Id;
-}
-
-int SeenMarkModel::seriaId() const
-{
-    return m_SeriaId;
-}
-
-void SeenMarkModel::setId(int id)
+void SeenMarkModel::setId(int id) noexcept
 {
     m_Id = id;
 }
 
-void SeenMarkModel::setSeriaId(int seriaId)
+void SeenMarkModel::setSeriaId(int seriaId) noexcept
 {
     m_SeriaId = seriaId;
 }
 
-void SeenMarkModel::writeToJson(QJsonObject &json) const
+void SeenMarkModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["seriaId"] = m_SeriaId;

--- a/src/Classes/Models/seenmarkmodel.h
+++ b/src/Classes/Models/seenmarkmodel.h
@@ -12,13 +12,13 @@ private:
     int m_SeriaId;
 
 public:
-    int id() const;
-    int seriaId() const;
+    int id() const {return m_Id;}
+    int seriaId() const {return m_SeriaId;}
 
-    void setId(int id);
-    void setSeriaId(int seriaId);
+    void setId(const int id) noexcept;
+    void setSeriaId(const int seriaId) noexcept;
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
     void readFromJson(QJsonValue &json);
 
 };

--- a/src/Classes/Models/seenmodel.cpp
+++ b/src/Classes/Models/seenmodel.cpp
@@ -4,47 +4,28 @@
 #include "seenmodel.h"
 
 
-int SeenModel::id()
-{
-    return m_Id;
-}
 
-int SeenModel::videoId() const
-{
-    return m_VideoId;
-}
-
-double SeenModel::videoPosition() const
-{
-    return m_VideoPosition;
-}
-
-int SeenModel::timestamp() const
-{
-    return m_Timestamp;
-}
-
-void SeenModel::setId(int id)
+void SeenModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-void SeenModel::setVideoId(int videoId)
+void SeenModel::setVideoId(const int videoId) noexcept
 {
     m_VideoId = videoId;
 }
 
-void SeenModel::setVideoPosition(double videoPosition)
+void SeenModel::setVideoPosition(const double videoPosition) noexcept
 {
     m_VideoPosition = videoPosition;
 }
 
-void SeenModel::setTimestamp(int timestamp)
+void SeenModel::setTimestamp(const int timestamp) noexcept
 {
     m_Timestamp = timestamp;
 }
 
-void SeenModel::writeToJson(QJsonObject &json) const
+void SeenModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["videoId"] = m_VideoId;

--- a/src/Classes/Models/seenmodel.h
+++ b/src/Classes/Models/seenmodel.h
@@ -13,17 +13,17 @@ private:
     int m_Timestamp;
 
 public:
-    int id();
-    int videoId() const;
-    double videoPosition() const;
-    int timestamp() const;
+    int id() const {return m_Id;}
+    int videoId() const {return  m_VideoId;}
+    double videoPosition() const {return m_VideoPosition;}
+    int timestamp() const {return m_Timestamp;}
 
-    void setId(int id);
-    void setVideoId(int videoId);
-    void setVideoPosition(double videoPosition);
-    void setTimestamp(int timestamp);
+    void setId(const int id) noexcept;
+    void setVideoId(const int videoId) noexcept;
+    void setVideoPosition(const double videoPosition) noexcept;
+    void setTimestamp(const int timestamp) noexcept;
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
     void readFromJson(QJsonValue &json);
 };
 

--- a/src/Classes/Models/usersettingsmodel.cpp
+++ b/src/Classes/Models/usersettingsmodel.cpp
@@ -12,82 +12,42 @@ UserSettingsModel::UserSettingsModel(): m_Quality(1),
 
 }
 
-int UserSettingsModel::quality()
-{
-    return m_Quality;
-}
-
-double UserSettingsModel::volume()
-{
-    return m_Volume;
-}
-
-bool UserSettingsModel::autoNextVideo()
-{
-    return m_AutoNextVideo;
-}
-
-bool UserSettingsModel::autoTopMost()
-{
-    return m_AutoTopMost;
-}
-
-int UserSettingsModel::torrentDownloadMode()
-{
-    return m_TorrentDownloadMode;
-}
-
-bool UserSettingsModel::notificationForFavorites()
-{
-    return m_NotificationForFavorites;
-}
-
-int UserSettingsModel::jumpMinute() const
-{
-    return m_JumpMinute;
-}
-
-int UserSettingsModel::jumpSecond() const
-{
-    return m_JumpSecond;
-}
-
-void UserSettingsModel::setQuality(int quality)
+void UserSettingsModel::setQuality(const int quality) noexcept
 {
     m_Quality = quality;
 }
 
-void UserSettingsModel::setVolume(double volume)
+void UserSettingsModel::setVolume(const double volume) noexcept
 {
     m_Volume = volume;
 }
 
-void UserSettingsModel::setAutoNextVideos(bool autoNextVideo)
+void UserSettingsModel::setAutoNextVideos(const bool autoNextVideo) noexcept
 {
     m_AutoNextVideo = autoNextVideo;
 }
 
-void UserSettingsModel::setAutoTopMost(bool autoTopMost)
+void UserSettingsModel::setAutoTopMost(const bool autoTopMost) noexcept
 {
     m_AutoTopMost = autoTopMost;
 }
 
-void UserSettingsModel::setTorrentDownloadMode(int torrentDownloadMode)
+void UserSettingsModel::setTorrentDownloadMode(const int torrentDownloadMode) noexcept
 {
     m_TorrentDownloadMode = torrentDownloadMode;
 }
 
-void UserSettingsModel::setNotificationForFavorites(bool notificationForFavorites)
+void UserSettingsModel::setNotificationForFavorites(const bool notificationForFavorites) noexcept
 {
     m_NotificationForFavorites = notificationForFavorites;
 }
 
-void UserSettingsModel::setJumpMinute(int jumpMinute)
+void UserSettingsModel::setJumpMinute(const int jumpMinute) noexcept
 {
     m_JumpMinute = jumpMinute;
 }
 
-void UserSettingsModel::setJumpSecond(int jumpSecond)
+void UserSettingsModel::setJumpSecond(const int jumpSecond) noexcept
 {
     m_JumpSecond = jumpSecond;
 }
@@ -109,7 +69,7 @@ void UserSettingsModel::fromJson(QString json)
     if (jsonSettings.contains("notificationForFavorites")) setNotificationForFavorites(jsonSettings.value("notificationForFavorites").toBool());
 }
 
-QString UserSettingsModel::toJson()
+QString UserSettingsModel::toJson() noexcept
 {
     QJsonObject object;
 

--- a/src/Classes/Models/usersettingsmodel.h
+++ b/src/Classes/Models/usersettingsmodel.h
@@ -21,26 +21,26 @@ private:
 public:
     UserSettingsModel();
 
-    int quality();
-    double volume();
-    bool autoNextVideo();
-    bool autoTopMost();
-    int torrentDownloadMode();
-    bool notificationForFavorites();
-    int jumpMinute() const;
-    int jumpSecond() const;
+    int quality() const {return m_Quality;}
+    double volume() const {return m_Volume;}
+    bool autoNextVideo() const {return m_AutoNextVideo;}
+    bool autoTopMost() const {return  m_AutoTopMost;}
+    int torrentDownloadMode() const {return  m_TorrentDownloadMode;}
+    bool notificationForFavorites() const {return  m_NotificationForFavorites;}
+    int jumpMinute() const {return m_JumpMinute;}
+    int jumpSecond() const {return m_JumpSecond;}
 
-    void setQuality(int quality);
-    void setVolume(double volume);
-    void setAutoNextVideos(bool autoNextVideo);
-    void setAutoTopMost(bool autoTopMost);
-    void setTorrentDownloadMode(int torrentDownloadMode);
-    void setNotificationForFavorites(bool notificationForFavorites);
-    void setJumpMinute(int jumpMinute);
-    void setJumpSecond(int jumpSecond);
+    void setQuality(const int quality) noexcept;
+    void setVolume(const double volume) noexcept;
+    void setAutoNextVideos(const bool autoNextVideo) noexcept;
+    void setAutoTopMost(const bool autoTopMost) noexcept;
+    void setTorrentDownloadMode(const int torrentDownloadMode) noexcept;
+    void setNotificationForFavorites(const bool notificationForFavorites) noexcept;
+    void setJumpMinute(const int jumpMinute) noexcept;
+    void setJumpSecond(const int jumpSecond) noexcept;
 
     void fromJson(QString json);
-    QString toJson();
+    QString toJson() noexcept;
 
 };
 

--- a/src/Classes/Models/youtubevideomodel.cpp
+++ b/src/Classes/Models/youtubevideomodel.cpp
@@ -10,57 +10,32 @@ YoutubeVideoModel::YoutubeVideoModel() :
 
 }
 
-int YoutubeVideoModel::id()
-{
-    return m_Id;
-}
-
-QString YoutubeVideoModel::title()
-{
-    return m_Title;
-}
-
-QString YoutubeVideoModel::image()
-{
-    return m_Image;
-}
-
-QString YoutubeVideoModel::videoIdentifier()
-{
-    return m_VideoIdentifier;
-}
-
-int YoutubeVideoModel::timestamp()
-{
-    return m_Timestamp;
-}
-
-void YoutubeVideoModel::setId(int id)
+void YoutubeVideoModel::setId(const int id) noexcept
 {
     m_Id = id;
 }
 
-void YoutubeVideoModel::setTitle(QString title)
+void YoutubeVideoModel::setTitle(const QString& title) noexcept
 {
     m_Title = title;
 }
 
-void YoutubeVideoModel::setImage(QString image)
+void YoutubeVideoModel::setImage(const QString& image) noexcept
 {
     m_Image = image;
 }
 
-void YoutubeVideoModel::setVideoIdentifier(QString videoIdentifier)
+void YoutubeVideoModel::setVideoIdentifier(const QString& videoIdentifier) noexcept
 {
     m_VideoIdentifier = videoIdentifier;
 }
 
-void YoutubeVideoModel::setTimestamp(int timestamp)
+void YoutubeVideoModel::setTimestamp(const int timestamp) noexcept
 {
     m_Timestamp = timestamp;
 }
 
-void YoutubeVideoModel::writeToJson(QJsonObject &json) const
+void YoutubeVideoModel::writeToJson(QJsonObject &json) const noexcept
 {
     json["id"] = m_Id;
     json["title"] = m_Title;

--- a/src/Classes/Models/youtubevideomodel.h
+++ b/src/Classes/Models/youtubevideomodel.h
@@ -18,19 +18,19 @@ private:
 public:
     YoutubeVideoModel();
 
-    int id();
-    QString title();
-    QString image();
-    QString videoIdentifier();
-    int timestamp();
+    int id() const {return m_Id;}
+    QString title() const {return m_Title;}
+    QString image() const {return m_Image;}
+    QString videoIdentifier() const {return  m_VideoIdentifier;}
+    int timestamp() const {return m_Timestamp;}
 
-    void setId(int id);
-    void setTitle(QString title);
-    void setImage(QString image);
-    void setVideoIdentifier(QString videoIdentifier);
-    void setTimestamp(int timestamp);
+    void setId(const int id) noexcept;
+    void setTitle(const QString& title) noexcept;
+    void setImage(const QString& image) noexcept;
+    void setVideoIdentifier(const QString& videoIdentifier) noexcept;
+    void setTimestamp(const int timestamp) noexcept;
 
-    void writeToJson(QJsonObject &json) const;
+    void writeToJson(QJsonObject &json) const noexcept;
     void readFromJson(QJsonValue &json);
 
 };


### PR DESCRIPTION
Почему гетеры перемещены в хедер? Есть 2 причины:


1)_Согласно правилу перезаписи, определение метода внутри объявления класса
эквивалентно замене определения метода прототипом и последующей перезаписью
определения в виде встроенной функции немедленно после объявления класса_;
2) Поскольку это модели и геттеры вряд ли будут меняться, целесообразно их сделать встроенными, тем самым повысить производительность и предотвратить долгий скролл. Думаю, когда эти модели будут дополняться функционалом, это способствует лучшей ориентации в коде.