### PR TITLE
Few online player tweaks + Desktop Entry fix.

### DIFF
--- a/data/anilibria.desktop
+++ b/data/anilibria.desktop
@@ -6,5 +6,5 @@ Icon=anilibria
 Type=Application
 Version=1.0.3
 Terminal=false
-Categories=Application;Multimedia;
+Categories=Qt;AudioVideo;Player;
 Keywords=anime;

--- a/src/Views/OnlinePlayer.qml
+++ b/src/Views/OnlinePlayer.qml
@@ -62,7 +62,7 @@ Page {
             onlinePlayerViewModel.nextVideo();
             event.accepted = true;
         }
-        if (event.key === Qt.Key_PageUp || event.nativeVirtualKey === Qt.Key_P || event.key === 1047) {
+        if (event.key === Qt.Key_PageUp || event.key === Qt.Key_P || event.key === 1047) {
             onlinePlayerViewModel.previousVideo();
             event.accepted = true;
         }
@@ -641,7 +641,7 @@ Page {
                     IconButton {
                         width: 40
                         height: 40
-                        iconColor: ApplicationTheme.filterIconButtonColor
+                        iconColor: player.muted ? ApplicationTheme.filterIconButtonGreenColor : ApplicationTheme.filterIconButtonColor
                         hoverColor: ApplicationTheme.filterIconButtonHoverColor
                         iconPath: "../Assets/Icons/speaker.svg"
                         iconWidth: 24
@@ -699,7 +699,7 @@ Page {
                         }
                         ToolTip.delay: 1000
                         ToolTip.visible: prevButton.hovered
-                        ToolTip.text: "Предыдущая серия (P)"
+                        ToolTip.text: "Предыдущая серия (P / PgUp)"
                     }
                     IconButton {
                         id: playButton
@@ -743,7 +743,7 @@ Page {
                         }
                         ToolTip.delay: 1000
                         ToolTip.visible: nextButton.hovered
-                        ToolTip.text: "Следующая серия (N)"
+                        ToolTip.text: "Следующая серия (N / PgDn)"
                     }
                     IconButton {
                         width: 40

--- a/src/Views/OnlinePlayer.qml
+++ b/src/Views/OnlinePlayer.qml
@@ -58,12 +58,12 @@ Page {
     }
 
     Keys.onPressed: {
-        if (event.key === Qt.Key_PageUp) {
+        if (event.key === Qt.Key_PageDown || event.key === Qt.Key_N) {
             onlinePlayerViewModel.nextVideo();
             event.accepted = true;
         }
-        if (event.key === Qt.Key_PageDown) {
-            _page.previousVideo();
+        if (event.key === Qt.Key_PageUp || event.key === Qt.Key_P) {
+            onlinePlayerViewModel.previousVideo();
             event.accepted = true;
         }
         if (event.key === Qt.Key_Escape) {
@@ -85,7 +85,7 @@ Page {
             volumeSlider.value = player.volume * 100;
         }
         if (event.key === Qt.Key_M || event.key === 1068) player.muted = !player.muted;
-        if ((event.key === Qt.Key_P || event.key === 1047) && !autoTopMost.checked) windowSettings.toggleStayOnTopMode();
+        if ((event.key === Qt.Key_T || event.key === 1047) && !autoTopMost.checked) windowSettings.toggleStayOnTopMode();
         if (event.key === Qt.Key_Left) player.seek(onlinePlayerViewModel.jumpInPlayer(jumpMinuteComboBox.currentIndex, jumpSecondComboBox.currentIndex, true));
         if (event.key === Qt.Key_Right) player.seek(onlinePlayerViewModel.jumpInPlayer(jumpMinuteComboBox.currentIndex, jumpSecondComboBox.currentIndex, false));
         if (event.key === Qt.Key_Escape) returnToReleasesPage();
@@ -686,6 +686,7 @@ Page {
                         }
                     }
                     IconButton {
+                        id: prevButton
                         width: 40
                         height: 40
                         iconColor: ApplicationTheme.filterIconButtonColor
@@ -696,6 +697,9 @@ Page {
                         onButtonPressed: {
                             onlinePlayerViewModel.previousVideo();
                         }
+                        ToolTip.delay: 1000
+                        ToolTip.visible: prevButton.hovered
+                        ToolTip.text: "Предыдущая серия (P)"
                     }
                     IconButton {
                         id: playButton
@@ -726,6 +730,7 @@ Page {
                         }
                     }
                     IconButton {
+                        id: nextButton
                         width: 40
                         height: 40
                         iconColor: ApplicationTheme.filterIconButtonColor
@@ -736,6 +741,9 @@ Page {
                         onButtonPressed: {
                             onlinePlayerViewModel.nextVideo();
                         }
+                        ToolTip.delay: 1000
+                        ToolTip.visible: nextButton.hovered
+                        ToolTip.text: "Следующая серия (N)"
                     }
                     IconButton {
                         width: 40
@@ -773,7 +781,7 @@ Page {
 
                         ToolTip.delay: 1000
                         ToolTip.visible: topmostButton.hovered
-                        ToolTip.text: windowSettings.isTopMost ? "Выключить режим поверх всех окон" : "Включить режим поверх всех окон"
+                        ToolTip.text: windowSettings.isTopMost ? "Выключить режим поверх всех окон (T)" : "Включить режим поверх всех окон (T)"
                     }
 
                     IconButton {

--- a/src/Views/OnlinePlayer.qml
+++ b/src/Views/OnlinePlayer.qml
@@ -58,11 +58,11 @@ Page {
     }
 
     Keys.onPressed: {
-        if (event.key === Qt.Key_PageDown || event.key === Qt.Key_N) {
+        if (event.key === Qt.Key_PageDown || event.key === Qt.Key_N || event.key === 1058) {
             onlinePlayerViewModel.nextVideo();
             event.accepted = true;
         }
-        if (event.key === Qt.Key_PageUp || event.key === Qt.Key_P) {
+        if (event.key === Qt.Key_PageUp || event.nativeVirtualKey === Qt.Key_P || event.key === 1047) {
             onlinePlayerViewModel.previousVideo();
             event.accepted = true;
         }
@@ -85,7 +85,7 @@ Page {
             volumeSlider.value = player.volume * 100;
         }
         if (event.key === Qt.Key_M || event.key === 1068) player.muted = !player.muted;
-        if ((event.key === Qt.Key_T || event.key === 1047) && !autoTopMost.checked) windowSettings.toggleStayOnTopMode();
+        if ((event.key === Qt.Key_T || event.key === 1045) && !autoTopMost.checked) windowSettings.toggleStayOnTopMode();
         if (event.key === Qt.Key_Left) player.seek(onlinePlayerViewModel.jumpInPlayer(jumpMinuteComboBox.currentIndex, jumpSecondComboBox.currentIndex, true));
         if (event.key === Qt.Key_Right) player.seek(onlinePlayerViewModel.jumpInPlayer(jumpMinuteComboBox.currentIndex, jumpSecondComboBox.currentIndex, false));
         if (event.key === Qt.Key_Escape) returnToReleasesPage();


### PR DESCRIPTION
* Added hotkey tooltips.
* Swapped PgUp and PgDn behavior.
* Changed always on top toggle hotkey. (P ==> T).
* Added alternative hotkeys for playing next and previous video. (N and P).
* Fixed previous video hotkey was implemented other way than next video hotkey. (line 66)

Resolves #53 

* Added AudioVIdeo, Player and Qt categories.
* Removed Multimedia and Application categories, which aren't listed in freedesktop's specs.

Resolves #55 