### PR TITLE
Fix "Version" key in anilibria.desktop

### DIFF
--- a/data/anilibria.desktop
+++ b/data/anilibria.desktop
@@ -4,7 +4,6 @@ Comment=AniLibria desktop client
 Exec=/opt/AniLibria/bin/AniLibria
 Icon=anilibria
 Type=Application
-Version=1.1.12
 Terminal=false
 Categories=Qt;AudioVideo;Player;
 Keywords=anime;


### PR DESCRIPTION
Ключ "Version" используется для указания версии файла спецификации desktop которому следует его описание, для совместимости лучше следовать версии 1.0. Однако этот ключ не является обязательным и его можно убрать. Подробнее о спецификации https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html