### PR TITLE
Check for null pointer (Падение в Бличе)

### DIFF
--- a/src/Classes/ListModels/releaseserieslistmodel.cpp
+++ b/src/Classes/ListModels/releaseserieslistmodel.cpp
@@ -55,7 +55,8 @@ QVariant ReleaseSeriesListModel::data(const QModelIndex &index, int role) const
     if (!index.isValid()) return QVariant();
 
     auto release = m_releases->at(index.row());
-
+    if(!release)
+        return QVariant();
     switch (role) {
         case IndexRole: {
             return QVariant(release->id());


### PR DESCRIPTION
При открытии страницы Блича, у меня приложение крашилось в **ReleaseSeriesListModel::data** из-за того, что **m_releases->at(index.row())** возвращал **null**. Проблему надо бы раскопать дальше, но проверка **release** на **null** прекратила падения и лишней не будет