### PR TITLE
fix: do not override pkg-config when building via nix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -441,7 +441,9 @@ endif ()
 if (APPLE)
     target_link_libraries(AniLiberty PRIVATE dl)
 
-    set(ENV{PKG_CONFIG_PATH} "/opt/homebrew/bin/pkg-config") # change path to PkgConfig (it can be founded in Qt directory which is not correct)
+    if (NOT (DEFINED ENV{NIX_STORE}))
+      set(ENV{PKG_CONFIG_PATH} "/opt/homebrew/bin/pkg-config") # change path to PkgConfig (it can be founded in Qt directory which is not correct)
+    endif()
 
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(LIBMPV REQUIRED IMPORTED_TARGET GLOBAL mpv)


### PR DESCRIPTION
when building via nix, pkg-config override not needed
env var NIX_STORE is kinda "marker" that build happens via nix, so if this variable is not defined, then "old" behavior (for regular macos build) is active (pkg-config from homebrew used), so if this env var exists then skipping pkg-config override